### PR TITLE
[iOS] Fix: Allow audioSession observer recreation after disposed

### DIFF
--- a/ios/Classes/VolumeObserver.swift
+++ b/ios/Classes/VolumeObserver.swift
@@ -88,6 +88,7 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
         notification.removeObserver(self,
                                     name: UIApplication.didBecomeActiveNotification,
                                     object: nil)
+        isObserving = false
     }
 
     


### PR DESCRIPTION
## Summary
Setting the `isObserving` flag to `false` when called the `removeVolumeObserver` function, to allow the `VolumeListener` re-create the `audioSession` observer if was disposed, and prevent crashes. 

Right now if you try this in iOS platform from first in one widget and then in another (preferentially on different screens), the second one won't work properly and if it gets disposed it will crash the app. 

```dart
StreamSubscription<double> volumeListener;
//...
  @override
  void initState() {
        super.initState();
        volumeListener = VolumeController.volumeListener.listen((volume) {
//...
   }

  @override
  void dispose() {
        if(volumeListener != null) {
            volumeListener.cancel();
        };
        super.dispose();
   }
//...
```