### PR TITLE
[iOS] Fix: Audio always mute after resume from background

### DIFF
--- a/ios/Classes/VolumeObserver.swift
+++ b/ios/Classes/VolumeObserver.swift
@@ -68,7 +68,7 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
     
     @objc func audioSessionObserver(){
         do {
-            try audioSession.setCategory(AVAudioSession.Category.ambient)
+            try audioSession.setCategory(AVAudioSession.Category.playback)
             try audioSession.setActive(true)
             if !isObserving {
                 audioSession.addObserver(self,


### PR DESCRIPTION
Setting AVAudioSession.Category to playback instead of ambient in the iOS class does not mute volume when app comes back from background.

This only happend when using the listener function
```
Volume controller().listener()
```

Fixes #4 