### PR TITLE
Suggestion: expose stream instead of listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,8 @@ A Flutter plugin for iOS and Android control system volume.
     > VolumeController().maxVolume({bool? showSystemUI})
 - muteVolume: mute the volume
     > VolumeController().muteVolume({bool? showSystemUI})
-- listener: listen system volume
-    > VolumeController().listener((volume) { // TODO });
-- removeListener: cancel listen system volume
-    > VolumeController().removeListener()
+- watchVolume: watches system volume
+    > VolumeController().watchVolume()
 
 ## Usage
 
@@ -32,6 +30,8 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  late final StreamSubscription<double> _subscription; 
+  
   double _volumeListenerValue = 0;
   double _getVolume = 0;
   double _setVolumeValue = 0;
@@ -40,7 +40,7 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
     // Listen to system volume change
-    VolumeController().listener((volume) {
+    _subscription = VolumeController().watchVolume().listen((volume) {
       setState(() => _volumeListenerValue = volume);
     });
 
@@ -49,7 +49,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
-    VolumeController().removeListener();
+    _subscription.cancel();
     super.dispose();
   }
 

--- a/lib/volume_controller.dart
+++ b/lib/volume_controller.dart
@@ -18,9 +18,6 @@ class VolumeController {
   /// This value is used to determine whether showing system UI
   bool showSystemUI = true;
 
-  /// Volume Listener Subscription
-  StreamSubscription<double>? _volumeListener;
-
   /// Singleton constructor
   VolumeController._();
 
@@ -31,17 +28,8 @@ class VolumeController {
   }
 
   /// This method listen to the system volume. The volume value will be generated when the volume was changed.
-  StreamSubscription<double> listener(Function(double)? onData) {
-    _volumeListener = _eventChannel
-        .receiveBroadcastStream()
-        .map((d) => d as double)
-        .listen(onData);
-    return _volumeListener!;
-  }
-
-  /// This method for canceling volume listener
-  void removeListener() {
-    _volumeListener?.cancel();
+  Stream<double> watchVolume() {
+    return _eventChannel.receiveBroadcastStream().map((d) => d as double);
   }
 
   /// This method get the current system volume.

--- a/lib/volume_controller.dart
+++ b/lib/volume_controller.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
-/// Provide the iOS/Androd system volume.
+/// Provide the iOS/Android system volume.
 class VolumeController {
   /// Singleton class instance
   static VolumeController? _instance;

--- a/lib/volume_controller.dart
+++ b/lib/volume_controller.dart
@@ -27,7 +27,8 @@ class VolumeController {
     return _instance!;
   }
 
-  /// This method listen to the system volume. The volume value will be generated when the volume was changed.
+  /// This method watches the system volume. A value will be generated each
+  /// time the volume was changed.
   Stream<double> watchVolume() {
     return _eventChannel.receiveBroadcastStream().map((d) => d as double);
   }


### PR DESCRIPTION
Did you ever consider exposing a `Stream<double>` instead of having the `listener()` and `removeListener()` methods which means you also manage the stream subscription yourself internally?

I guess maybe you want to keep it simpler for end users consuming the plugin? But IMO developers are/should be capable of managing a stream subscription. 

An advantage of exposing a stream instead of a subscription means consumers can chain operations and manipulate the stream type like:

```dart
  final StreamSubscription<int> subscription = VolumeController()
      .watchVolume()
      .map((value) => (value * 100).toInt())
      .listen((volume) {
    // int result
  });
```

---

If you wanted to keep it this way, I would make listener() return a void, so that the caller does not create an unnecessary copy of the stream subscription (since you already manage it).