### PR TITLE
fix(ios): Set the audio category to "mixWithOthers" to prevent stopping other apps' audio

### DIFF
--- a/ios/Classes/VolumeObserver.swift
+++ b/ios/Classes/VolumeObserver.swift
@@ -74,7 +74,7 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
 
     @objc func audioSessionObserver(){
         do {
-            try audioSession.setCategory(AVAudioSession.Category.playback)
+            try audioSession.setCategory(AVAudioSession.Category.playback, options: AVAudioSession.CategoryOptions.mixWithOthers)
             try audioSession.setActive(true)
             if !isObserving {
                 audioSession.addObserver(self,


### PR DESCRIPTION
Fixes: https://github.com/kurenai7968/volume_controller/issues/17