### PR TITLE
fix: audio focus

### DIFF
--- a/ios/volume_controller/Sources/volume_controller/Extension.swift
+++ b/ios/volume_controller/Sources/volume_controller/Extension.swift
@@ -6,39 +6,3 @@ extension Comparable {
     return min(max(self, limits.lowerBound), limits.upperBound)
   }
 }
-
-extension AVAudioSession {
-  func getVolume() -> Float {
-    do {
-      try setActive(true)
-      return outputVolume
-    } catch {
-      print("Error activating audio session: \(error)")
-      return 0
-    }
-  }
-
-  func activateAudioSession() {
-    do {
-      try setActive(true)
-    } catch {
-      print("Error activating audio session: \(error)")
-    }
-  }
-
-  func deactivateAudioSession() {
-    do {
-      try setActive(false)
-    } catch {
-      print("Error deactivating audio session: \(error)")
-    }
-  }
-
-  func setAudioSessionCategory() {
-    do {
-      try setCategory(.playback, options: .mixWithOthers)
-    } catch {
-      print("Error setting audio session category: \(error)")
-    }
-  }
-}

--- a/ios/volume_controller/Sources/volume_controller/VolumeController.swift
+++ b/ios/volume_controller/Sources/volume_controller/VolumeController.swift
@@ -12,7 +12,7 @@ public class VolumeController {
   }
 
   public func getVolume() -> Float {
-    return audioSession.getVolume()
+    return audioSession.outputVolume
   }
 
   public func setVolume(volume: Float, showSystemUI: Bool) {

--- a/ios/volume_controller/Sources/volume_controller/VolumeControllerPlugin.swift
+++ b/ios/volume_controller/Sources/volume_controller/VolumeControllerPlugin.swift
@@ -55,9 +55,6 @@ public class VolumeControllerPlugin: NSObject, FlutterPlugin {
 
 extension VolumeControllerPlugin: FlutterApplicationLifeCycleDelegate {
   public func applicationWillEnterForeground(_ application: UIApplication) {
-    VolumeControllerPlugin.audioSession.activateAudioSession()
-    VolumeControllerPlugin.audioSession.setAudioSessionCategory()
-
     if VolumeControllerPlugin.volumeListener.isObservingVolume {
       VolumeControllerPlugin.volumeListener.sendVolumeChangeEvent()
     }

--- a/ios/volume_controller/Sources/volume_controller/VolumeListener.swift
+++ b/ios/volume_controller/Sources/volume_controller/VolumeListener.swift
@@ -9,7 +9,6 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
   private var eventSink: FlutterEventSink?
   private var isObserving: Bool = false
   private let volumeKey: String = "outputVolume"
-  private var didActivateAudioSession: Bool = false
 
   init(audioSession: AVAudioSession) {
     self.audioSession = audioSession
@@ -29,17 +28,13 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
     registerVolumeObserver()
 
     if fetchInitialVolume {
-      events(audioSession.getVolume())
+      events(audioSession.outputVolume)
     }
 
     return nil
   }
 
   public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-    if didActivateAudioSession {
-      audioSession.deactivateAudioSession()
-      didActivateAudioSession = false
-    }
     eventSink = nil
     removeVolumeObserver()
 
@@ -48,10 +43,6 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
 
   private func registerVolumeObserver() {
     do {
-      try audioSession.setAudioSessionCategory()
-      try audioSession.activateAudioSession()
-      didActivateAudioSession = true
-
       if !isObserving {
         audioSession.addObserver(
           self,
@@ -81,10 +72,10 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
     guard keyPath == volumeKey else {
       return
     }
-    eventSink?(audioSession.getVolume())
+    eventSink?(audioSession.outputVolume)
   }
 
   public func sendVolumeChangeEvent() {
-    eventSink?(audioSession.getVolume())
+    eventSink?(audioSession.outputVolume)
   }
 }

--- a/ios/volume_controller/Sources/volume_controller/VolumeListener.swift
+++ b/ios/volume_controller/Sources/volume_controller/VolumeListener.swift
@@ -9,6 +9,7 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
   private var eventSink: FlutterEventSink?
   private var isObserving: Bool = false
   private let volumeKey: String = "outputVolume"
+  private var didActivateAudioSession: Bool = false
 
   init(audioSession: AVAudioSession) {
     self.audioSession = audioSession
@@ -35,7 +36,10 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
   }
 
   public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-    audioSession.deactivateAudioSession()
+    if didActivateAudioSession {
+      audioSession.deactivateAudioSession()
+      didActivateAudioSession = false
+    }
     eventSink = nil
     removeVolumeObserver()
 
@@ -46,6 +50,8 @@ public class VolumeListener: NSObject, FlutterStreamHandler {
     do {
       try audioSession.setAudioSessionCategory()
       try audioSession.activateAudioSession()
+      didActivateAudioSession = true
+
       if !isObserving {
         audioSession.addObserver(
           self,


### PR DESCRIPTION
close #34 

I think `volume_controller` should not control a shared AudioSession. 
Because just reading or subscribing to a volume may stop audio or video from other services.