### PR TITLE
feat: update version to 3.6.1; enhance Windows plugin stability and e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.6.1
+
+* Windows: Send volume listener events on the Flutter platform thread
+* Windows: Update GoogleTest so plugin tests configure with CMake 4
+* Windows: Dispatch volume events through a message-only window created on the Flutter platform thread
+
 ## 3.6.0
 
 * Update minimum supported SDKs to Flutter 3.44 and Dart 3.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.6.1
 
+* Windows: Release the volume callback when notification registration fails because no audio endpoint is available
 * Windows: Send volume listener events on the Flutter platform thread
 * Windows: Update GoogleTest so plugin tests configure with CMake 4
 * Windows: Dispatch volume events through a message-only window created on the Flutter platform thread

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   path:
     dependency: transitive
     description:
@@ -180,18 +180,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -206,7 +206,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.6.0"
+    version: "3.6.1"
 sdks:
   dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.44.0"

--- a/example/windows/CMakeLists.txt
+++ b/example/windows/CMakeLists.txt
@@ -52,8 +52,9 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 # Application build; see runner/CMakeLists.txt.
 add_subdirectory("runner")
 
-# Enable the test target.
-set(include_volume_controller_tests TRUE)
+# Plugin unit tests pull in GoogleTest via FetchContent. Keep them off for the
+# example app so CMake 4+ and GoogleTest do not affect running the example.
+set(include_volume_controller_tests FALSE)
 
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   path:
     dependency: transitive
     description:
@@ -180,18 +180,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: volume_controller
 description: A Flutter volume plugin for multiple platform to control system volume.
-version: 3.6.0
+version: 3.6.1
 homepage: https://github.com/kurenai7968/volume_controller
 
 environment:

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -77,10 +77,11 @@ set(TEST_RUNNER "${PROJECT_NAME}_test")
 enable_testing()
 
 # Add the Google Test dependency.
+# 1.11.0 is rejected by CMake 4+, which dropped compatibility with < 3.5.
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/release-1.11.0.zip
+  URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
 )
 # Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/windows/include/volume_controller/volume_callback.h
+++ b/windows/include/volume_controller/volume_callback.h
@@ -48,7 +48,10 @@ namespace volume_callback
         // IAudioEndpointVolumeCallback method
         HRESULT STDMETHODCALLTYPE OnNotify(PAUDIO_VOLUME_NOTIFICATION_DATA pNotify) override
         {
-            on_volume_change_(pNotify->fMasterVolume);
+            if (pNotify && on_volume_change_)
+            {
+                on_volume_change_(pNotify->fMasterVolume);
+            }
             return S_OK;
         }
 

--- a/windows/include/volume_controller/volume_listener.cpp
+++ b/windows/include/volume_controller/volume_listener.cpp
@@ -58,32 +58,43 @@ namespace volume_listener
 
     void VolumeListener::Dispose()
     {
+        DisposeVolumeNotification();
         if (pVolume_)
+        {
             pVolume_->Release();
+            pVolume_ = nullptr;
+        }
         CoUninitialize();
     }
 
     bool VolumeListener::RegisterVolumeNotification(volume_callback::VolumeCallback *callback)
     {
-        HRESULT hr = E_FAIL;
-        pCallback_ = callback;
+        DisposeVolumeNotification();
 
-        hr = pVolume_->RegisterControlChangeNotify(pCallback_);
-        if (FAILED(hr))
+        if (!pVolume_ || !callback)
         {
-            std::cerr << "Failed to register volume notification: " << hr << std::endl;
             return false;
         }
 
+        HRESULT hr = pVolume_->RegisterControlChangeNotify(callback);
+        if (FAILED(hr))
+        {
+            std::cerr << "Failed to register volume notification: " << hr << std::endl;
+            callback->Release();
+            return false;
+        }
+
+        pCallback_ = callback;
         return true;
     }
 
     void VolumeListener::DisposeVolumeNotification()
     {
-        if (pCallback_)
+        if (pVolume_ && pCallback_)
         {
             pVolume_->UnregisterControlChangeNotify(pCallback_);
             pCallback_->Release();
+            pCallback_ = nullptr;
         }
     }
 }

--- a/windows/include/volume_controller/volume_listener.cpp
+++ b/windows/include/volume_controller/volume_listener.cpp
@@ -73,6 +73,10 @@ namespace volume_listener
 
         if (!pVolume_ || !callback)
         {
+            if (callback)
+            {
+                callback->Release();
+            }
             return false;
         }
 

--- a/windows/include/volume_controller/volume_stream_handler.cpp
+++ b/windows/include/volume_controller/volume_stream_handler.cpp
@@ -2,14 +2,24 @@
 
 namespace volume_stream_handler
 {
-    // VolumeStreamHandler::VolumeStreamHandler() : volume_listener_(volume_listener::VolumeListener::GetInstance())
-    VolumeStreamHandler::VolumeStreamHandler() : volume_listener_(volume_listener::VolumeListener::GetInstance())
+    namespace
+    {
+        constexpr UINT kPostTaskMessage = WM_APP + 1;
+        constexpr wchar_t kPlatformWindowClass[] =
+            L"com.kurenai7968.volume_controller.PlatformThread";
+    }
+
+    VolumeStreamHandler::VolumeStreamHandler()
+        : volume_listener_(volume_listener::VolumeListener::GetInstance())
     {
         volume_listener_.Initialize();
     }
 
     VolumeStreamHandler::~VolumeStreamHandler()
     {
+        volume_listener_.DisposeVolumeNotification();
+        event_sink_ = nullptr;
+        DestroyPlatformWindow();
         volume_listener_.Dispose();
     }
 
@@ -19,6 +29,10 @@ namespace volume_stream_handler
     {
         const flutter::EncodableMap *args_map = std::get_if<flutter::EncodableMap>(arguments);
         const bool *fetchInitialVolume = std::get_if<bool>(GetArgValue(*args_map, constants::EventArgument::fetchInitialVolume));
+
+        // EventChannel handlers run on the Flutter platform thread. Create the
+        // message-only window here so its WndProc also runs on that thread.
+        EnsurePlatformWindow();
 
         event_sink_ = std::move(events);
 
@@ -30,8 +44,6 @@ namespace volume_stream_handler
         if (fetchInitialVolume && *fetchInitialVolume)
         {
             float volume = volume_controller::VolumeController::GetInstance().GetVolume();
-
-            // Send the initial volume
             event_sink_->Success(flutter::EncodableValue(volume));
         }
 
@@ -41,15 +53,111 @@ namespace volume_stream_handler
     std::unique_ptr<flutter::StreamHandlerError<flutter::EncodableValue>> VolumeStreamHandler::OnCancelInternal(
         const flutter::EncodableValue *arguments)
     {
+        volume_listener_.DisposeVolumeNotification();
+        DrainPendingTasks();
         event_sink_ = nullptr;
         return nullptr;
     }
 
     void VolumeStreamHandler::SendVolumeChangeEvent(float volume)
     {
-        if (event_sink_)
+        PostToPlatformThread([this, volume]()
+                             {
+                                 if (event_sink_)
+                                 {
+                                     event_sink_->Success(flutter::EncodableValue(volume));
+                                 }
+                             });
+    }
+
+    void VolumeStreamHandler::EnsurePlatformWindow()
+    {
+        if (hwnd_)
         {
-            event_sink_->Success(flutter::EncodableValue(volume));
+            return;
         }
+
+        platform_thread_id_ = GetCurrentThreadId();
+
+        HMODULE instance = GetPluginModule();
+        WNDCLASSW window_class = {};
+        window_class.lpfnWndProc = WndProc;
+        window_class.hInstance = instance;
+        window_class.lpszClassName = kPlatformWindowClass;
+        RegisterClassW(&window_class);
+
+        hwnd_ = CreateWindowExW(0, kPlatformWindowClass, L"", 0, 0, 0, 0, 0,
+                                HWND_MESSAGE, nullptr, instance, nullptr);
+        if (hwnd_)
+        {
+            SetWindowLongPtrW(hwnd_, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
+        }
+    }
+
+    void VolumeStreamHandler::DestroyPlatformWindow()
+    {
+        DrainPendingTasks();
+        if (hwnd_)
+        {
+            DestroyWindow(hwnd_);
+            hwnd_ = nullptr;
+        }
+    }
+
+    void VolumeStreamHandler::PostToPlatformThread(std::function<void()> task)
+    {
+        if (!hwnd_)
+        {
+            return;
+        }
+
+        if (platform_thread_id_ != 0 && GetCurrentThreadId() == platform_thread_id_)
+        {
+            task();
+            return;
+        }
+
+        auto *posted_task = new std::function<void()>(std::move(task));
+        if (!PostMessageW(hwnd_, kPostTaskMessage, reinterpret_cast<WPARAM>(posted_task), 0))
+        {
+            delete posted_task;
+        }
+    }
+
+    void VolumeStreamHandler::DrainPendingTasks()
+    {
+        if (!hwnd_)
+        {
+            return;
+        }
+
+        MSG message;
+        while (PeekMessageW(&message, hwnd_, kPostTaskMessage, kPostTaskMessage, PM_REMOVE))
+        {
+            delete reinterpret_cast<std::function<void()> *>(message.wParam);
+        }
+    }
+
+    HMODULE VolumeStreamHandler::GetPluginModule()
+    {
+        HMODULE module = nullptr;
+        GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           reinterpret_cast<LPCWSTR>(&GetPluginModule), &module);
+        return module;
+    }
+
+    LRESULT CALLBACK VolumeStreamHandler::WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam)
+    {
+        auto *self = reinterpret_cast<VolumeStreamHandler *>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+        if (self && message == kPostTaskMessage)
+        {
+            auto *task = reinterpret_cast<std::function<void()> *>(wparam);
+            (*task)();
+            delete task;
+            return 0;
+        }
+
+        return DefWindowProcW(hwnd, message, wparam, lparam);
     }
 }

--- a/windows/include/volume_controller/volume_stream_handler.h
+++ b/windows/include/volume_controller/volume_stream_handler.h
@@ -3,8 +3,9 @@
 
 #include <flutter/event_channel.h>
 #include <flutter/encodable_value.h>
+#include <windows.h>
+#include <functional>
 #include <memory>
-#include <mutex>
 
 #include "constants.h"
 #include "volume_listener.h"
@@ -30,8 +31,18 @@ namespace volume_stream_handler
             const flutter::EncodableValue *arguments) override;
 
     private:
+        void EnsurePlatformWindow();
+        void DestroyPlatformWindow();
+        void PostToPlatformThread(std::function<void()> task);
+        void DrainPendingTasks();
+
+        static LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam);
+        static HMODULE GetPluginModule();
+
         std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink_;
         volume_listener::VolumeListener &volume_listener_;
+        HWND hwnd_ = nullptr;
+        DWORD platform_thread_id_ = 0;
     };
 }
 

--- a/windows/volume_controller_plugin.cpp
+++ b/windows/volume_controller_plugin.cpp
@@ -46,7 +46,8 @@ namespace volume_controller
         });
 
     // Register the event channel
-    event_channel->SetStreamHandler(std::make_unique<volume_stream_handler::VolumeStreamHandler>());
+    event_channel->SetStreamHandler(
+        std::make_unique<volume_stream_handler::VolumeStreamHandler>());
 
     // Set the channel to the plugin
     registrar->AddPlugin(std::move(plugin));


### PR DESCRIPTION
…vent handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Native Windows COM and threading changes around volume notifications can cause crashes or missed events if marshaling or lifetime is wrong. Scope is Windows-only and does not touch auth or data handling.
> 
> **Overview**
> Releases **3.6.1** with Windows volume-listener stability fixes.
> 
> WASAPI volume callbacks now hop to the Flutter platform thread via a message-only window, so `EventSink` is not used from the audio callback thread. Registration failures (no audio endpoint) release the callback instead of leaking it, and dispose/unregister is more careful about null COM pointers.
> 
> Plugin tests fetch GoogleTest **v1.17.0** for CMake 4; the example app no longer builds those tests. Analyzer configs exclude platform/build trees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd545ad4b97df7df2aefabdef56394a61af07403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->